### PR TITLE
Make link sniffer not sniff if !nosniff is in the string.

### DIFF
--- a/src/SnifferHelper.php
+++ b/src/SnifferHelper.php
@@ -33,6 +33,8 @@ class SnifferHelper
 	{
 		if (empty($string))
 			throw new NoUriFoundException();
+		elseif (strpos($string, '!nosniff') !== false)
+			throw new NoUriFoundException();
 
 		$hasMatches = preg_match('/https?\:\/\/[A-Za-z0-9\-\/._~:?#@!$&\'()*+,;=%]+/i', $string, $matches);
 
@@ -63,7 +65,7 @@ class SnifferHelper
 			{
 				$title = trim($matches[1]);
 				$title = html_entity_decode($title, ENT_QUOTES | ENT_HTML401);
-				
+
 				// Abort the operation.
 				return false;
 			}

--- a/tests/SnifferTest.php
+++ b/tests/SnifferTest.php
@@ -34,6 +34,14 @@ class SnifferTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($expected, $result);
 	}
 
+	/**
+	 * @expectedException WildPHP\Modules\LinkSniffer\NoUriFoundException
+	 */
+	public function testIgnoresLinkIfNosniffKeywordIsPresent()
+	{
+	    SnifferHelper::extractUriFromString('http://google.com !nosniff');
+	}
+	
 	public function testGetTitle()
 	{
 		$expected = 'Google';
@@ -51,4 +59,6 @@ class SnifferTest extends \PHPUnit_Framework_TestCase
 
 		$this->assertSame($expected, $result);
 	}
+
+
 }


### PR DESCRIPTION
Because we shouldn't sniff if we can't sniff, because !nosniff prohibits us from sniffing things we shouldn't sniff.

Signed-off-by: Archer70 <code.archer70@gmail.com>